### PR TITLE
Allow configuration of validation path

### DIFF
--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -43,6 +43,9 @@ defmodule Ueberauth.Strategy.CAS do
     The strategy only supports the required params, `service` and `ticket`.
     There is no support for other params.
 
+    The validation path can be overridden via configuration to comply with
+    CAS 3.0 and use `/p3/serviceValidate`.
+
   ## Errors
 
   If the login fails, the strategy will fail with error key `missing_ticket`.
@@ -73,6 +76,7 @@ defmodule Ueberauth.Strategy.CAS do
   config :ueberauth, Ueberauth,
      providers: [cas: {Ueberauth.Strategy.CAS, [
        base_url: "http://cas.example.com",
+       validation_path: "/serviceValidate",
        callback: "http://your-app.example.com/auth/cas/callback",
        attributes: %{
           last_name: "surname"

--- a/lib/ueberauth/strategy/cas/api.ex
+++ b/lib/ueberauth/strategy/cas/api.ex
@@ -53,8 +53,12 @@ defmodule Ueberauth.Strategy.CAS.API do
     {error_code || "unknown_error", message || "Unknown error"}
   end
 
-  defp validate_url do
-    settings(:base_url) <> "/serviceValidate"
+  def validate_url do
+    settings(:base_url) <> validate_path()
+  end
+
+  defp validate_path do
+    settings(:validation_path) || "/serviceValidate"
   end
 
   defp settings(key) do


### PR DESCRIPTION
Allow to configure validation path to be able to use the strategy with a CAS server that uses CAS 3.0 specifications.

I didn't find a real difference between CAS 2.0 and CAS 3.0 validation but the validation path.
[/p3/serviceValidate [CAS 3.0]](https://apereo.github.io/cas/4.2.x/protocol/CAS-Protocol-Specification.html#head2.8).
I've tested the validation with a real CAS 3.0 server without any issue.

I didn't find a way to properly test the modification since the `service_url` function is a private one. However I'm ready to modify anything that bothers you.