### PR TITLE
Dynamic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Central Authentication Service strategy for Überauth.
    config :ueberauth, Ueberauth,
      providers: [cas: {Ueberauth.Strategy.CAS, [
        base_url: "http://cas.example.com",
-       callback: "http://your-app.example.com/auth/cas/callback",
+       callback_url: "http://your-app.example.com/auth/cas/callback",
      ]}]
    ```
 
 4. Include the Überauth plug in your controller:
-  
+
    ```elixir
    defmodule MyApp.AuthController do
      use MyApp.Web, :controller

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,1 @@
 use Mix.Config
-
-config :ueberauth, Ueberauth,
-  providers: [
-    cas: {Ueberauth.Strategy.CAS, [base_url: "http://cas.example.com", service: "http://svc.example.com"]}
-  ]

--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -220,4 +220,32 @@ defmodule Ueberauth.Strategy.CAS do
       value
     end
   end
+
+  defp redirect_url(conn) do
+    login_url(conn) <> "?service=" <> callback_url(conn)
+  end
+
+  defp validate_url(conn) do
+    base_url(conn) <> validation_path(conn)
+  end
+
+  defp login_url(conn) do
+    base_url(conn) <> "/login"
+  end
+
+  defp base_url(conn) do
+    Keyword.get(settings(conn), :base_url)
+  end
+
+  defp validation_path(conn) do
+    Keyword.get(settings(conn), :validation_path, "/serviceValidate")
+  end
+
+  defp attributes(conn) do
+    Keyword.get(settings(conn), :attributes, %{})
+  end
+
+  defp settings(conn) do
+    Ueberauth.Strategy.Helpers.options(conn) || []
+  end
 end

--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -77,7 +77,7 @@ defmodule Ueberauth.Strategy.CAS do
      providers: [cas: {Ueberauth.Strategy.CAS, [
        base_url: "http://cas.example.com",
        validation_path: "/serviceValidate",
-       callback: "http://your-app.example.com/auth/cas/callback",
+       callback_url: "http://your-app.example.com/auth/cas/callback",
        attributes: %{
           last_name: "surname"
        },

--- a/lib/ueberauth/strategy/cas/api.ex
+++ b/lib/ueberauth/strategy/cas/api.ex
@@ -3,19 +3,14 @@ defmodule Ueberauth.Strategy.CAS.API do
   CAS server API implementation.
   """
 
-  use Ueberauth.Strategy
   alias Ueberauth.Strategy.CAS
 
   import SweetXml
 
-  @doc "Returns the URL to this CAS server's login page."
-  def login_url do
-    settings(:base_url) <> "/login"
-  end
-
   @doc "Validate a CAS Service Ticket with the CAS server."
-  def validate_ticket(ticket, conn) do
-    HTTPoison.get(validate_url(), [], params: %{ticket: ticket, service: callback_url(conn)})
+  def validate_ticket(ticket, validate_url, service) do
+    validate_url
+    |> HTTPoison.get([], params: %{ticket: ticket, service: service})
     |> handle_validate_ticket_response()
   end
 
@@ -51,18 +46,5 @@ defmodule Ueberauth.Strategy.CAS.API do
       |> sanitize_string()
 
     {error_code || "unknown_error", message || "Unknown error"}
-  end
-
-  def validate_url do
-    settings(:base_url) <> validate_path()
-  end
-
-  defp validate_path do
-    settings(:validation_path) || "/serviceValidate"
-  end
-
-  defp settings(key) do
-    {_, settings} = Application.get_env(:ueberauth, Ueberauth)[:providers][:cas]
-    settings[key]
   end
 end

--- a/test/ueberauth/strategy/cas/api_test.exs
+++ b/test/ueberauth/strategy/cas/api_test.exs
@@ -4,10 +4,6 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
 
   alias Ueberauth.Strategy.CAS.API
 
-  test "generates a cas login url" do
-    assert API.login_url() == "http://cas.example.com/login"
-  end
-
   test "validates a valid ticket response" do
     ok_xml = """
     <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
@@ -33,7 +29,7 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
         {:ok, %HTTPoison.Response{status_code: 200, body: ok_xml, headers: []}}
       end do
       {:ok, %Ueberauth.Strategy.CAS.User{name: name}} =
-        API.validate_ticket("ST-XXXXX", %Plug.Conn{})
+        API.validate_ticket("ST-XXXXX", "http://cas.example.com/serviceValidate", "service_name")
 
       assert name == "mail@marceldegraaf.net"
     end
@@ -50,7 +46,8 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
       get: fn _url, _opts, _params ->
         {:ok, %HTTPoison.Response{status_code: 200, body: error_xml, headers: []}}
       end do
-      {:error, {code, message}} = API.validate_ticket("ST-XXXXX", %Plug.Conn{})
+      {:error, {code, message}} =
+        API.validate_ticket("ST-XXXXX", "http://cas.example.com/serviceValidate", "service_name")
 
       assert code == "INVALID_TICKET"
       assert message == "Ticket 'ST-XXXXX' already consumed"
@@ -68,7 +65,8 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
       get: fn _url, _opts, _params ->
         {:ok, %HTTPoison.Response{status_code: 200, body: unknown_error_xml, headers: []}}
       end do
-      {:error, {code, message}} = API.validate_ticket("ST-XXXXX", %Plug.Conn{})
+      {:error, {code, message}} =
+        API.validate_ticket("ST-XXXXX", "http://cas.example.com/serviceValidate", "service_name")
 
       assert code == "unknown_error"
       assert message == "An unknown error occurred"
@@ -86,7 +84,8 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
       get: fn _url, _opts, _params ->
         {:ok, %HTTPoison.Response{status_code: 200, body: unknown_error_xml, headers: []}}
       end do
-      {:error, {code, message}} = API.validate_ticket("ST-XXXXX", %Plug.Conn{})
+      {:error, {code, message}} =
+        API.validate_ticket("ST-XXXXX", "http://cas.example.com/serviceValidate", "service_name")
 
       assert code == "CONNECTION_ERROR"
       assert message == "Unknown error"
@@ -104,7 +103,8 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
       get: fn _url, _opts, _params ->
         {:ok, %HTTPoison.Response{status_code: 200, body: unknown_error_xml, headers: []}}
       end do
-      {:error, {code, message}} = API.validate_ticket("ST-XXXXX", %Plug.Conn{})
+      {:error, {code, message}} =
+        API.validate_ticket("ST-XXXXX", "http://cas.example.com/serviceValidate", "service_name")
 
       assert code == "unknown_error"
       assert message == "Unknown error"
@@ -116,7 +116,8 @@ defmodule Ueberauth.Strategy.CAS.API.Test do
       get: fn _url, _opts, _params ->
         {:ok, %HTTPoison.Response{status_code: 200, body: "blip blob", headers: []}}
       end do
-      {:error, {code, _}} = API.validate_ticket("ST-XXXXX", %Plug.Conn{})
+      {:error, {code, _}} =
+        API.validate_ticket("ST-XXXXX", "http://cas.example.com/serviceValidate", "service_name")
 
       assert code == "malformed_xml"
     end

--- a/test/ueberauth/strategy/cas_test.exs
+++ b/test/ueberauth/strategy/cas_test.exs
@@ -6,10 +6,26 @@ defmodule Ueberauth.Strategy.CAS.Test do
   alias Ueberauth.Strategy.CAS
 
   setup do
+    ueberauth_request_options = %{
+      callback_url: "http://service.com/auth/provider/callback",
+      options: [
+        base_url: "http://cas.example.com",
+        validate_path: "serviceValidate"
+      ]
+    }
+
     conn = %Plug.Conn{
       private: %{
-        cas_user: %CAS.User{name: "Marcel de Graaf", attributes: %{"email" => "mail@marceldegraaf.net", "roles" => ["developer"], "first_name" => ["Joe", "Example"]}},
-        cas_ticket: "ST-XXXXX",
+        ueberauth_request_options: ueberauth_request_options,
+        cas_user: %CAS.User{
+          name: "Marcel de Graaf",
+          attributes: %{
+            "email" => "mail@marceldegraaf.net",
+            "roles" => ["developer"],
+            "first_name" => ["Joe", "Example"]
+          }
+        },
+        cas_ticket: "ST-XXXXX"
       }
     }
 
@@ -39,13 +55,24 @@ defmodule Ueberauth.Strategy.CAS.Test do
       conn: conn,
       ok_xml: ok_xml,
       error_xml: error_xml,
+      ueberauth_request_options: ueberauth_request_options
     }
   end
 
-  test "redirect callback redirects to login url" do
-    conn = conn(:get, "/login") |> CAS.handle_request!
+  test "redirect callback redirects to login url", %{
+    ueberauth_request_options: ueberauth_request_options
+  } do
+    conn =
+      conn(:get, "/login")
+      |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
+      |> CAS.handle_request!()
 
     assert conn.status == 302
+
+    assert Plug.Conn.get_resp_header(conn, "location") ==
+             [
+               "http://cas.example.com/login?service=http://service.com/auth/provider/callback"
+             ]
   end
 
   test "login callback without service ticket shows an error" do
@@ -53,13 +80,18 @@ defmodule Ueberauth.Strategy.CAS.Test do
     assert Map.has_key?(conn.assigns, :ueberauth_failure)
   end
 
-  test "successful login callback validates the ticket", %{ok_xml: xml} do
-    with_mock HTTPoison, [
-      get: fn(_url, _opts, _params) ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}
-      } end
-    ] do
-      conn = CAS.handle_callback!(%Plug.Conn{params: %{"ticket" => "ST-XXXXX"}})
+  test "successful login callback validates the ticket", %{
+    ok_xml: xml,
+    ueberauth_request_options: ueberauth_request_options
+  } do
+    with_mock HTTPoison,
+      get: fn _url, _opts, _params ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
+      end do
+      conn =
+        %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
+        |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
+        |> CAS.handle_callback!()
 
       assert conn.private.cas_ticket == "ST-XXXXX"
       assert conn.private.cas_user.name == "mail@marceldegraaf.net"
@@ -67,29 +99,40 @@ defmodule Ueberauth.Strategy.CAS.Test do
     end
   end
 
-  test "invalid login callback returns an error", %{error_xml: xml} do
-    with_mock HTTPoison, [
-      get: fn(_url, _opts, _params) ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}
-      } end
-    ] do
-      conn = CAS.handle_callback!(%Plug.Conn{params: %{"ticket" => "ST-XXXXX"}})
+  test "invalid login callback returns an error", %{
+    error_xml: xml,
+    ueberauth_request_options: ueberauth_request_options
+  } do
+    with_mock HTTPoison,
+      get: fn _url, _opts, _params ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
+      end do
+      conn =
+        %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
+        |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
+        |> CAS.handle_callback!()
 
       assert List.first(conn.assigns.ueberauth_failure.errors).message_key == "INVALID_TICKET"
-      assert List.first(conn.assigns.ueberauth_failure.errors).message == "Ticket 'ST-XXXXX' already consumed"
+
+      assert List.first(conn.assigns.ueberauth_failure.errors).message ==
+               "Ticket 'ST-XXXXX' already consumed"
     end
   end
 
-  test "network error propagates" do
-    with_mock HTTPoison, [
-      get: fn(_url, _opts, _params) ->
+  test "network error propagates", %{ueberauth_request_options: ueberauth_request_options} do
+    with_mock HTTPoison,
+      get: fn _url, _opts, _params ->
         {:error, %HTTPoison.Error{reason: :timeout, id: nil}}
-      end
-    ] do
-      conn = CAS.handle_callback!(%Plug.Conn{params: %{"ticket" => "ST-XXXXX"}})
+      end do
+      conn =
+        %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
+        |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
+        |> CAS.handle_callback!()
 
       assert List.first(conn.assigns.ueberauth_failure.errors).message_key == "NETWORK_ERROR"
-      assert List.first(conn.assigns.ueberauth_failure.errors).message == "An error occurred: timeout"
+
+      assert List.first(conn.assigns.ueberauth_failure.errors).message ==
+               "An error occurred: timeout"
     end
   end
 


### PR DESCRIPTION
I've added support for multiple CAS strategies and dynamic configuration.

**How**
The strategy configuration is extracted from `%Plug.Con{}` and not from the config file.
All functions that extract configuration have been moved to `CAS` module.
`CAS.API` no longer relies on injecting `%Plug.Conn{}` to perform a ticket validation.

**Notes**
I've tested this branch in a phoenix application to make sure there's no breaking change.

With this change it is possible to dynamically inject CAS strategies and their configuration according to the [Ueberauth documentation](https://hexdocs.pm/ueberauth/Ueberauth.html#run_request/4).

Eg.
```elixir
defmodule CasWeb.Router do
  use CasWeb, :router

  #...

  scope "/", CasWeb do
    pipe_through(:browser)

    get("/auth/:provider", AuthController, :request)
    get("/auth/:provider/callback", AuthController, :callback)
  end
end



defmodule CasWeb.AuthController do
  use CasWeb, :controller

  alias Ueberauth.Strategy.Helpers

  def request(conn, %{"provider" => provider} = _params) do
    provider_config =
      case provider do
        "alpha" ->
          {Ueberauth.Strategy.CAS,
           [
             base_url: "https://alpha.test/cas",
             callback_url: "https://cas_service.test/auth/alpha/callback",
             attributes: %{
               email: "mail",
               first_name: "given_name",
               last_name: "sn"
             }
           ]}

        "beta" ->
          {Ueberauth.Strategy.CAS,
           [
             base_url: "https://beta.test/cas",
             callback_url: "https://cas_service.test/auth/beta/callback",
             attributes: %{
               email: "mail",
               first_name: "given_name",
               last_name: "sn"
             }
           ]}
      end

    conn
    |> Ueberauth.run_request(provider, provider_config)
  end

  def callback(conn, %{"provider" => provider} = params) do
    provider_config =
      case provider do
        "alpha" ->
          {Ueberauth.Strategy.CAS,
           [
             base_url: "https://alpha.test/cas",
             callback_url: "https://cas_service.test/auth/alphacallback",
             attributes: %{
               email: "mail",
               first_name: "given_name",
               last_name: "sn"
             }
           ]}

        "beta" ->
          {Ueberauth.Strategy.CAS,
           [
             base_url: "https://beta.test/cas",
             callback_url: "https://cas_service.test/auth/beta/callback",
             attributes: %{
               email: "mail",
               first_name: "given_name",
               last_name: "sn"
             }
           ]}
      end

    conn
    |> Ueberauth.run_callback(provider, provider_config)
    |> handle_callback(params)
  end

  def handle_callback(%{assigns: %{ueberauth_failure: fails}} = conn, _params) do
    text(conn, inspect(fails))
  end

  def handle_callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
    text(conn, inspect(auth))
  end
end
```
