### PR TITLE
Remove application from mix.exs file

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,12 +22,6 @@ defmodule UeberauthCAS.Mixfile do
     ]
   end
 
-  def application do
-    [
-      applications: [:logger, :ueberauth, :httpoison]
-    ]
-  end
-
   defp deps do
     [
       {:ueberauth, "~> 0.6.3"},


### PR DESCRIPTION
As mentioned in #12, there is no need to add this these days, and it breaks some applications.

Fixes #12