### PR TITLE
Bump Elixir versions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,13 +9,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.8.2
+          - elixir: 1.9.4
             otp: 22
-          - elixir: 1.12.3
-            otp: 24.1
+          - elixir: 1.13.3
+            otp: 24.2
             test-options: "--warnings-as-errors"
-          - elixir: 1.12.3
-            otp: 24.1
+          - elixir: 1.13.3
+            otp: 24.2
             unlock: true
             test-options: "--warnings-as-errors"
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule UeberauthCAS.Mixfile do
     [
       app: :ueberauth_cas,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       name: "Ueberauth CAS",
       package: package(),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
1.8 is no longer supported, also test 1.13