### PR TITLE
feat: New :sanitize_attribute_names option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Central Authentication Service (CAS) strategy for Überauth.
      providers: [cas: {Ueberauth.Strategy.CAS, [
        base_url: "http://cas.example.com",
        callback_url: "http://your-app.example.com/auth/cas/callback",
+       # sanitize_attribute_names: false,
      ]}]
    ```
 

--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -69,6 +69,9 @@ defmodule Ueberauth.Strategy.CAS do
   By default, attributes are the same as the Überauth field.
   For example, the field `:last_name` will be set from an attribute `cas:lastName`.
 
+  This can be disabled by explicitely setting the `:sanitize_attribute_names`
+   option to `false`.
+
   ### Configuring Überauth mapping
 
   The mapping can be specified in the configuration:
@@ -181,7 +184,7 @@ defmodule Ueberauth.Strategy.CAS do
 
   defp fetch_user(conn, ticket) do
     ticket
-    |> CAS.API.validate_ticket(validate_url(conn), callback_url(conn))
+    |> CAS.API.validate_ticket(validate_url(conn), callback_url(conn), settings(conn))
     |> handle_validate_ticket_response(conn)
   end
 

--- a/lib/ueberauth/strategy/cas/api.ex
+++ b/lib/ueberauth/strategy/cas/api.ex
@@ -14,7 +14,10 @@ defmodule Ueberauth.Strategy.CAS.API do
     |> handle_validate_ticket_response(opts)
   end
 
-  defp handle_validate_ticket_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}, opts) do
+  defp handle_validate_ticket_response(
+         {:ok, %HTTPoison.Response{status_code: 200, body: body}},
+         opts
+       ) do
     # We catch XML parse errors, but they will still be shown in the logs.
     # Therefore, we must first parse quietly and then use xpath.
     # See https://github.com/kbrw/sweet_xml/issues/48

--- a/lib/ueberauth/strategy/cas/api.ex
+++ b/lib/ueberauth/strategy/cas/api.ex
@@ -8,20 +8,20 @@ defmodule Ueberauth.Strategy.CAS.API do
   import SweetXml
 
   @doc "Validate a CAS Service Ticket with the CAS server."
-  def validate_ticket(ticket, validate_url, service) do
+  def validate_ticket(ticket, validate_url, service, opts \\ []) do
     validate_url
     |> HTTPoison.get([], params: %{ticket: ticket, service: service})
-    |> handle_validate_ticket_response()
+    |> handle_validate_ticket_response(opts)
   end
 
-  defp handle_validate_ticket_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
+  defp handle_validate_ticket_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}, opts) do
     # We catch XML parse errors, but they will still be shown in the logs.
     # Therefore, we must first parse quietly and then use xpath.
     # See https://github.com/kbrw/sweet_xml/issues/48
     try do
       case xpath(parse(body, quiet: true), ~x"//cas:serviceResponse/cas:authenticationSuccess") do
         nil -> {:error, error_from_body(body)}
-        _ -> {:ok, CAS.User.from_xml(body)}
+        _ -> {:ok, CAS.User.from_xml(body, opts)}
       end
     catch
       :exit, {_type, reason} ->
@@ -29,7 +29,7 @@ defmodule Ueberauth.Strategy.CAS.API do
     end
   end
 
-  defp handle_validate_ticket_response({:error, %HTTPoison.Error{reason: reason}}) do
+  defp handle_validate_ticket_response({:error, %HTTPoison.Error{reason: reason}}, _opts) do
     {:error, reason}
   end
 

--- a/test/ueberauth/strategy/cas/user_test.exs
+++ b/test/ueberauth/strategy/cas/user_test.exs
@@ -51,4 +51,36 @@ defmodule Ueberauth.Strategy.CAS.User.Test do
              "numbers" => ["1", "3", "2"]
            }
   end
+
+  test "attribute names are not modified when :sanitize_attribute_names option is false" do
+    response = """
+    <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+      <cas:authenticationSuccess>
+        <cas:user>janedoe</cas:user>
+        <cas:attributes>
+          <cas:firstName>Jane</cas:firstName>
+          <cas:last_name>Doe</cas:last_name>
+          <cas:mail>jane.doe@mail.test</cas:mail>
+          <cas:OtherMail>jane.doe@other.test</cas:OtherMail>
+          <cas:Affiliation>staff</cas:Affiliation>
+          <cas:Affiliation>faculty</cas:Affiliation>
+          <cas:OTHER_ATTRIBUTE>123</cas:OTHER_ATTRIBUTE>
+        </cas:attributes>
+      </cas:authenticationSuccess>
+    </cas:serviceResponse>
+    """
+
+    user = User.from_xml(response, sanitize_attribute_names: false)
+
+    assert user.name == "janedoe"
+
+    assert user.attributes == %{
+             "firstName" => "Jane",
+             "last_name" => "Doe",
+             "mail" => "jane.doe@mail.test",
+             "OtherMail" => "jane.doe@other.test",
+             "Affiliation" => ["staff", "faculty"],
+             "OTHER_ATTRIBUTE" => "123"
+           }
+  end
 end


### PR DESCRIPTION
So that the default attributes mapping can be disabled as needed.