### PR TITLE
Feat: New :multivalued_attributes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Central Authentication Service (CAS) strategy for Überauth.
        base_url: "http://cas.example.com",
        callback_url: "http://your-app.example.com/auth/cas/callback",
        # sanitize_attribute_names: false,
+       # multivalued_attributes: :first,
      ]}]
    ```
 

--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -162,13 +162,55 @@ defmodule Ueberauth.Strategy.CAS do
 
     %Info{
       name: user.name,
-      email: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :email),
-      birthday: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :birthday),
-      description: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :description),
-      first_name: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :first_name),
-      last_name: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :last_name),
-      nickname: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :nickname),
-      phone: get_attribute(attribute_mapping, user_attributes, multivalued_attributes_management, :phone)
+      email:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :email
+        ),
+      birthday:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :birthday
+        ),
+      description:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :description
+        ),
+      first_name:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :first_name
+        ),
+      last_name:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :last_name
+        ),
+      nickname:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :nickname
+        ),
+      phone:
+        get_attribute(
+          attribute_mapping,
+          user_attributes,
+          multivalued_attributes_management,
+          :phone
+        )
     }
   end
 

--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -213,7 +213,7 @@ defmodule Ueberauth.Strategy.CAS do
     if is_list(value) do
       case multivalued_attributes_management do
         :first -> Enum.at(value, 0)
-        :last -> Enum.last(value)
+        :last -> List.last(value)
         :list -> value
       end
     else

--- a/lib/ueberauth/strategy/cas.ex
+++ b/lib/ueberauth/strategy/cas.ex
@@ -88,6 +88,11 @@ defmodule Ueberauth.Strategy.CAS do
      ]}]
   ```
 
+  ### Multivalued attributes management
+  By default, only the first value is kept in case of multivalued attributes.
+  This behaviour can be managed with the `mutivalued_attributes` option,
+   which can be set to `:first`, `:last` or `:list`.
+
   [login]: https://apereo.github.io/cas/6.2.x/protocol/CAS-Protocol-Specification.html#21-login-as-credential-requestor
   [validate]: https://apereo.github.io/cas/6.2.x/protocol/CAS-Protocol-Specification.html#25-servicevalidate-cas-20
   """

--- a/test/ueberauth/strategy/cas_test.exs
+++ b/test/ueberauth/strategy/cas_test.exs
@@ -194,6 +194,32 @@ defmodule Ueberauth.Strategy.CAS.Test do
       assert info.name == "Marcel de Graaf"
       assert info.first_name == "Joe"
     end
+
+    test "multiple info works when multivalued_attributes is set to :last", %{conn: conn} do
+      conn =
+        update_in(
+          conn.private.ueberauth_request_options.options,
+          &Keyword.put(&1, :multivalued_attributes, :last)
+        )
+
+      info = CAS.info(conn)
+
+      assert info.name == "Marcel de Graaf"
+      assert info.first_name == "Example"
+    end
+
+    test "multiple info works when multivalued_attributes is set to :list", %{conn: conn} do
+      conn =
+        update_in(
+          conn.private.ueberauth_request_options.options,
+          &Keyword.put(&1, :multivalued_attributes, :list)
+        )
+
+      info = CAS.info(conn)
+
+      assert info.name == "Marcel de Graaf"
+      assert info.first_name == ["Joe", "Example"]
+    end
   end
 
   test "generates credentials struct", %{conn: conn} do

--- a/test/ueberauth/strategy/cas_test.exs
+++ b/test/ueberauth/strategy/cas_test.exs
@@ -195,6 +195,19 @@ defmodule Ueberauth.Strategy.CAS.Test do
       assert info.first_name == "Joe"
     end
 
+    test "multiple info works when multivalued_attributes is set to :first", %{conn: conn} do
+      conn =
+        update_in(
+          conn.private.ueberauth_request_options.options,
+          &Keyword.put(&1, :multivalued_attributes, :first)
+        )
+
+      info = CAS.info(conn)
+
+      assert info.name == "Marcel de Graaf"
+      assert info.first_name == "Joe"
+    end
+
     test "multiple info works when multivalued_attributes is set to :last", %{conn: conn} do
       conn =
         update_in(


### PR DESCRIPTION
Hello,

The idea here is to be able to control how multivalued attributes are handled.
Currently, the attribute value in the Info struct is set to the **first** value in the list.

Our problem is that we're migrating from a Ruby on Rails project that relies on Omniauth, which set the attribute value to the **last** value in the list.

The default would still be to use the first value to prevent breaking changes.