### PR TITLE
Erh/JTC-1670: add multivalued attributes management

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Central Authentication Service (CAS) strategy for Überauth.
        base_url: "http://cas.example.com",
        callback_url: "http://your-app.example.com/auth/cas/callback",
        # sanitize_attribute_names: false,
+       # multivalued_attributes: :first,
      ]}]
    ```
 
@@ -72,6 +73,12 @@ implementation. Please let me know if Überauth CAS is incompatible with your CA
 server, and why.
 
 The docs contain more information about protocol specifics.
+
+## Why Jobteaser Forked this repo
+
+We decided to fork this repository to add two functionalities:
+- add an option to specify how mutlivalued attributes should be handled
+- add an option to get the XML payload (TODO)
 
 ## Copyright and License
 

--- a/test/ueberauth/strategy/cas_test.exs
+++ b/test/ueberauth/strategy/cas_test.exs
@@ -87,9 +87,9 @@ defmodule Ueberauth.Strategy.CAS.Test do
     ueberauth_request_options: ueberauth_request_options
   } do
     with_mock HTTPoison,
-      get: fn _url, _opts, _params ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
-      end do
+              get: fn _url, _opts, _params ->
+                {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
+              end do
       conn =
         %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
         |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
@@ -112,9 +112,9 @@ defmodule Ueberauth.Strategy.CAS.Test do
       )
 
     with_mock HTTPoison,
-      get: fn _url, _opts, _params ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
-      end do
+              get: fn _url, _opts, _params ->
+                {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
+              end do
       conn =
         %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
         |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
@@ -135,9 +135,9 @@ defmodule Ueberauth.Strategy.CAS.Test do
     ueberauth_request_options: ueberauth_request_options
   } do
     with_mock HTTPoison,
-      get: fn _url, _opts, _params ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
-      end do
+              get: fn _url, _opts, _params ->
+                {:ok, %HTTPoison.Response{status_code: 200, body: xml, headers: []}}
+              end do
       conn =
         %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
         |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
@@ -152,9 +152,9 @@ defmodule Ueberauth.Strategy.CAS.Test do
 
   test "network error propagates", %{ueberauth_request_options: ueberauth_request_options} do
     with_mock HTTPoison,
-      get: fn _url, _opts, _params ->
-        {:error, %HTTPoison.Error{reason: :timeout, id: nil}}
-      end do
+              get: fn _url, _opts, _params ->
+                {:error, %HTTPoison.Error{reason: :timeout, id: nil}}
+              end do
       conn =
         %Plug.Conn{params: %{"ticket" => "ST-XXXXX"}}
         |> Plug.Conn.put_private(:ueberauth_request_options, ueberauth_request_options)
@@ -193,6 +193,45 @@ defmodule Ueberauth.Strategy.CAS.Test do
 
       assert info.name == "Marcel de Graaf"
       assert info.first_name == "Joe"
+    end
+
+    test "multiple info works when multivalued_attributes is set to :first", %{conn: conn} do
+      conn =
+        update_in(
+          conn.private.ueberauth_request_options.options,
+          &Keyword.put(&1, :multivalued_attributes, :first)
+        )
+
+      info = CAS.info(conn)
+
+      assert info.name == "Marcel de Graaf"
+      assert info.first_name == "Joe"
+    end
+
+    test "multiple info works when multivalued_attributes is set to :last", %{conn: conn} do
+      conn =
+        update_in(
+          conn.private.ueberauth_request_options.options,
+          &Keyword.put(&1, :multivalued_attributes, :last)
+        )
+
+      info = CAS.info(conn)
+
+      assert info.name == "Marcel de Graaf"
+      assert info.first_name == "Example"
+    end
+
+    test "multiple info works when multivalued_attributes is set to :list", %{conn: conn} do
+      conn =
+        update_in(
+          conn.private.ueberauth_request_options.options,
+          &Keyword.put(&1, :multivalued_attributes, :list)
+        )
+
+      info = CAS.info(conn)
+
+      assert info.name == "Marcel de Graaf"
+      assert info.first_name == ["Joe", "Example"]
     end
   end
 

--- a/ueberauth_cas.iml
+++ b/ueberauth_cas.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="ELIXIR_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Add an `multivalued_attributes` option to define how multivalued attributes are handled 